### PR TITLE
Add sport test v1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/src/test/java/seedu/address/logic/commands/AddSportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSportCommandTest.java
@@ -1,0 +1,119 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Sport;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code AddSportCommand}.
+ */
+public class AddSportCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullSport_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), null));
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() throws Exception {
+        Person personToModify = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Sport sportToAdd = new Sport("soccer");
+        AddSportCommand addSportCommand = new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), sportToAdd);
+
+        String expectedMessage = String.format(AddSportCommand.MESSAGE_SUCCESS, 
+                sportToAdd.toString(), personToModify.getName().fullName);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Person modifiedPerson = createPersonWithAdditionalSport(personToModify, sportToAdd);
+        expectedModel.setPerson(personToModify, modifiedPerson);
+
+        assertEquals(addSportCommand.execute(model), new CommandResult(expectedMessage));
+        assertEquals(expectedModel, model);
+    }
+
+    @Test
+    public void execute_duplicateSport_throwsCommandException() {
+        Person personToModify = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Sport sportToAdd = new Sport("soccer");
+        
+        // First add a sport
+        Person modifiedPerson = createPersonWithAdditionalSport(personToModify, sportToAdd);
+        model.setPerson(personToModify, modifiedPerson);
+        
+        // Try to add the same sport again
+        AddSportCommand addSportCommand = new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), sportToAdd);
+        assertThrows(CommandException.class, 
+                AddSportCommand.MESSAGE_DUPLICATE_SPORT, () -> addSportCommand.execute(model));
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        int outOfBoundIndex = model.getFilteredPersonList().size();
+        AddSportCommand addSportCommand = new AddSportCommand(outOfBoundIndex, new Sport("soccer"));
+
+        assertThrows(CommandException.class, 
+                "Invalid person index", () -> addSportCommand.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        Sport soccer = new Sport("soccer");
+        Sport basketball = new Sport("basketball");
+        AddSportCommand addSoccerCommand = new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), soccer);
+        AddSportCommand addBasketballCommand = new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), basketball);
+        AddSportCommand addSoccerSecondCommand = new AddSportCommand(INDEX_SECOND_PERSON.getZeroBased(), soccer);
+
+        // same object -> returns true
+        assertTrue(addSoccerCommand.equals(addSoccerCommand));
+
+        // same values -> returns true
+        AddSportCommand addSoccerCommandCopy = new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), soccer);
+        assertTrue(addSoccerCommand.equals(addSoccerCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addSoccerCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addSoccerCommand.equals(null));
+
+        // different sport -> returns false
+        assertFalse(addSoccerCommand.equals(addBasketballCommand));
+
+        // different index -> returns false
+        assertFalse(addSoccerCommand.equals(addSoccerSecondCommand));
+    }
+
+    /**
+     * Creates a new person with all the same fields as the original, plus an additional sport.
+     */
+    private Person createPersonWithAdditionalSport(Person person, Sport sport) {
+        List<Sport> updatedSports = new ArrayList<>(person.getSports());
+        updatedSports.add(sport);
+        
+        return new Person(
+                person.getName(),
+                person.getPhone(),
+                person.getEmail(),
+                person.getAddress(),
+                person.getTags(),
+                updatedSports);
+    }
+} 

--- a/src/test/java/seedu/address/logic/commands/AddSportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSportCommandTest.java
@@ -38,7 +38,7 @@ public class AddSportCommandTest {
         Sport sportToAdd = new Sport("soccer");
         AddSportCommand addSportCommand = new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), sportToAdd);
 
-        String expectedMessage = String.format(AddSportCommand.MESSAGE_SUCCESS, 
+        String expectedMessage = String.format(AddSportCommand.MESSAGE_SUCCESS,
                 sportToAdd.toString(), personToModify.getName().fullName);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
@@ -53,14 +53,14 @@ public class AddSportCommandTest {
     public void execute_duplicateSport_throwsCommandException() {
         Person personToModify = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Sport sportToAdd = new Sport("soccer");
-        
+
         // First add a sport
         Person modifiedPerson = createPersonWithAdditionalSport(personToModify, sportToAdd);
         model.setPerson(personToModify, modifiedPerson);
-        
+
         // Try to add the same sport again
         AddSportCommand addSportCommand = new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), sportToAdd);
-        assertThrows(CommandException.class, 
+        assertThrows(CommandException.class,
                 AddSportCommand.MESSAGE_DUPLICATE_SPORT, () -> addSportCommand.execute(model));
     }
 
@@ -69,7 +69,7 @@ public class AddSportCommandTest {
         int outOfBoundIndex = model.getFilteredPersonList().size();
         AddSportCommand addSportCommand = new AddSportCommand(outOfBoundIndex, new Sport("soccer"));
 
-        assertThrows(CommandException.class, 
+        assertThrows(CommandException.class,
                 "Invalid person index", () -> addSportCommand.execute(model));
     }
 
@@ -107,7 +107,7 @@ public class AddSportCommandTest {
     private Person createPersonWithAdditionalSport(Person person, Sport sport) {
         List<Sport> updatedSports = new ArrayList<>(person.getSports());
         updatedSports.add(sport);
-        
+
         return new Person(
                 person.getName(),
                 person.getPhone(),
@@ -116,4 +116,4 @@ public class AddSportCommandTest {
                 person.getTags(),
                 updatedSports);
     }
-} 
+}

--- a/src/test/java/seedu/address/logic/parser/AddSportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddSportCommandParserTest.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddSportCommand;
+import seedu.address.model.person.Sport;
+import seedu.address.logic.parser.ParserUtil;
+
+public class AddSportCommandParserTest {
+    private static final String VALID_SPORT = "soccer";
+    private static final String INVALID_SPORT = "invalid-sport";
+
+    private AddSportCommandParser parser = new AddSportCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        // Valid sport
+        AddSportCommand expectedCommand = 
+            new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), new Sport(VALID_SPORT));
+        assertParseSuccess(parser, "1 s/soccer", expectedCommand);
+
+        // With whitespace
+        assertParseSuccess(parser, " 1   s/soccer   ", expectedCommand);
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSportCommand.MESSAGE_USAGE);
+
+        // Missing index
+        assertParseFailure(parser, "s/soccer", expectedMessage);
+
+        // Missing sport
+        assertParseFailure(parser, "1", expectedMessage);
+
+        // Missing sport prefix
+        assertParseFailure(parser, "1 soccer", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // Invalid index
+        assertParseFailure(parser, "0 s/soccer", 
+            ParserUtil.MESSAGE_INVALID_INDEX);
+        
+        // Empty sport
+        assertParseFailure(parser, "1 s/", 
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSportCommand.MESSAGE_USAGE));
+
+        // Invalid format
+        assertParseFailure(parser, "1s/soccer", 
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSportCommand.MESSAGE_USAGE));
+    }
+} 

--- a/src/test/java/seedu/address/logic/parser/AddSportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddSportCommandParserTest.java
@@ -3,13 +3,13 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddSportCommand;
 import seedu.address.model.person.Sport;
-import seedu.address.logic.parser.ParserUtil;
 
 public class AddSportCommandParserTest {
     private static final String VALID_SPORT = "soccer";
@@ -20,8 +20,8 @@ public class AddSportCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         // Valid sport
-        AddSportCommand expectedCommand = 
-            new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), new Sport(VALID_SPORT));
+        AddSportCommand expectedCommand =
+                new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), new Sport(VALID_SPORT));
         assertParseSuccess(parser, "1 s/soccer", expectedCommand);
 
         // With whitespace
@@ -45,15 +45,15 @@ public class AddSportCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         // Invalid index
-        assertParseFailure(parser, "0 s/soccer", 
-            ParserUtil.MESSAGE_INVALID_INDEX);
-        
+        assertParseFailure(parser, "0 s/soccer",
+                MESSAGE_INVALID_INDEX);
+
         // Empty sport
-        assertParseFailure(parser, "1 s/", 
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 s/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSportCommand.MESSAGE_USAGE));
 
         // Invalid format
-        assertParseFailure(parser, "1s/soccer", 
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSportCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1s/soccer",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSportCommand.MESSAGE_USAGE));
     }
-} 
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddSportCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -25,6 +26,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Sport;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -86,6 +88,14 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_addSport() throws Exception {
+        final Sport sport = new Sport("soccer");
+        AddSportCommand command = (AddSportCommand) parser.parseCommand(
+                AddSportCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " s/soccer");
+        assertEquals(new AddSportCommand(INDEX_FIRST_PERSON.getZeroBased(), sport), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -7,8 +7,10 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Sport;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -35,6 +38,12 @@ public class ParserUtilTest {
     private static final String VALID_TAG_2 = "neighbour";
 
     private static final String WHITESPACE = " \t\r\n";
+
+    // Tests for sport parsing
+    
+    private static final String INVALID_SPORT = "cricket123";
+    private static final String VALID_SPORT_1 = "soccer";
+    private static final String VALID_SPORT_2 = "basketball";
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
@@ -192,5 +201,51 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseSport_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseSports((String) null));
+    }
+
+    @Test
+    public void parseSport_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseSports(INVALID_SPORT));
+    }
+
+    @Test
+    public void parseSport_validValueWithoutWhitespace_returnsSport() throws Exception {
+        Sport expectedSport = new Sport(VALID_SPORT_1);
+        assertEquals(expectedSport, ParserUtil.parseSports(VALID_SPORT_1));
+    }
+
+    @Test
+    public void parseSport_validValueWithWhitespace_returnsTrimmedSport() throws Exception {
+        String sportWithWhitespace = WHITESPACE + VALID_SPORT_1 + WHITESPACE;
+        Sport expectedSport = new Sport(VALID_SPORT_1);
+        assertEquals(expectedSport, ParserUtil.parseSports(sportWithWhitespace));
+    }
+
+    @Test
+    public void parseSports_collectionWithValidSports_returnsSportList() throws Exception {
+        List<String> sportStrings = Arrays.asList(VALID_SPORT_1, VALID_SPORT_2);
+        List<Sport> expectedSportList = new ArrayList<>();
+        expectedSportList.add(new Sport(VALID_SPORT_1));
+        expectedSportList.add(new Sport(VALID_SPORT_2));
+        
+        List<Sport> actualSportList = ParserUtil.parseSports(sportStrings);
+        assertEquals(expectedSportList.size(), actualSportList.size());
+        assertTrue(actualSportList.containsAll(expectedSportList));
+    }
+
+    @Test
+    public void parseSports_emptyCollection_returnsEmptyList() throws Exception {
+        assertTrue(ParserUtil.parseSports(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void parseSports_collectionWithInvalidSports_throwsParseException() {
+        assertThrows(ParseException.class, () -> 
+                ParserUtil.parseSports(Arrays.asList(VALID_SPORT_1, INVALID_SPORT)));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -6,8 +6,8 @@ import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -40,7 +40,6 @@ public class ParserUtilTest {
     private static final String WHITESPACE = " \t\r\n";
 
     // Tests for sport parsing
-    
     private static final String INVALID_SPORT = "cricket123";
     private static final String VALID_SPORT_1 = "soccer";
     private static final String VALID_SPORT_2 = "basketball";
@@ -232,7 +231,7 @@ public class ParserUtilTest {
         List<Sport> expectedSportList = new ArrayList<>();
         expectedSportList.add(new Sport(VALID_SPORT_1));
         expectedSportList.add(new Sport(VALID_SPORT_2));
-        
+
         List<Sport> actualSportList = ParserUtil.parseSports(sportStrings);
         assertEquals(expectedSportList.size(), actualSportList.size());
         assertTrue(actualSportList.containsAll(expectedSportList));
@@ -245,7 +244,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseSports_collectionWithInvalidSports_throwsParseException() {
-        assertThrows(ParseException.class, () -> 
+        assertThrows(ParseException.class, () ->
                 ParserUtil.parseSports(Arrays.asList(VALID_SPORT_1, INVALID_SPORT)));
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -12,14 +12,12 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 public class PersonTest {
 
@@ -127,7 +125,7 @@ public class PersonTest {
         Person originalPerson = new PersonBuilder().build();
         List<Sport> updatedSports = new ArrayList<>(originalPerson.getSports());
         updatedSports.add(new Sport("tennis"));
-        
+
         Person updatedPerson = new Person(
                 originalPerson.getName(),
                 originalPerson.getPhone(),
@@ -135,7 +133,7 @@ public class PersonTest {
                 originalPerson.getAddress(),
                 originalPerson.getTags(),
                 updatedSports);
-        
+
         assertTrue(updatedPerson.getSports().contains(new Sport("tennis")));
         assertEquals(originalPerson.getSports().size() + 1, updatedPerson.getSports().size());
     }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -16,6 +16,11 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public class PersonTest {
 
     @Test
@@ -96,5 +101,42 @@ public class PersonTest {
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags();
         expected = expected + ", sports=[]}";
         assertEquals(expected, ALICE.toString());
+    }
+
+    @Test
+    public void getSports_modifyList_throwsUnsupportedOperationException() {
+        Person person = new PersonBuilder().build();
+        assertThrows(UnsupportedOperationException.class, () -> person.getSports().remove(0));
+    }
+
+    @Test
+    public void hasSport_personWithNoSports_returnsFalse() {
+        Person person = new PersonBuilder().build();
+        Sport sport = new Sport("basketball");
+        assertFalse(person.getSports().contains(sport));
+    }
+
+    @Test
+    public void hasSport_personWithSport_returnsTrue() {
+        Person person = new PersonBuilder().withSport("soccer").build();
+        assertTrue(person.getSports().contains(new Sport("soccer")));
+    }
+
+    @Test
+    public void addSport_success() {
+        Person originalPerson = new PersonBuilder().build();
+        List<Sport> updatedSports = new ArrayList<>(originalPerson.getSports());
+        updatedSports.add(new Sport("tennis"));
+        
+        Person updatedPerson = new Person(
+                originalPerson.getName(),
+                originalPerson.getPhone(),
+                originalPerson.getEmail(),
+                originalPerson.getAddress(),
+                originalPerson.getTags(),
+                updatedSports);
+        
+        assertTrue(updatedPerson.getSports().contains(new Sport("tennis")));
+        assertEquals(originalPerson.getSports().size() + 1, updatedPerson.getSports().size());
     }
 }

--- a/src/test/java/seedu/address/model/person/SportTest.java
+++ b/src/test/java/seedu/address/model/person/SportTest.java
@@ -64,4 +64,4 @@ public class SportTest {
         Sport secondSport = new Sport("Rugby");
         assertFalse(firstSport.equals(secondSport));
     }
-} 
+}

--- a/src/test/java/seedu/address/model/person/SportTest.java
+++ b/src/test/java/seedu/address/model/person/SportTest.java
@@ -1,0 +1,67 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class SportTest {
+
+    @Test
+    public void constructor_validSport_success() {
+        // Valid sport names
+        Sport sport = new Sport("Basketball");
+        assertNotNull(sport);
+        assertEquals("Basketball", sport.sportName);
+
+        sport = new Sport("Tennis");
+        assertNotNull(sport);
+        assertEquals("Tennis", sport.sportName);
+    }
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Sport(null));
+    }
+
+    @Test
+    public void toString_validSport_returnsSportName() {
+        Sport sport = new Sport("Soccer");
+        assertEquals("Soccer", sport.toString());
+    }
+
+    @Test
+    public void equals_sameObject_returnsTrue() {
+        Sport sport = new Sport("Badminton");
+        assertTrue(sport.equals(sport));
+    }
+
+    @Test
+    public void equals_sameValue_returnsTrue() {
+        Sport firstSport = new Sport("Tennis");
+        Sport secondSport = new Sport("Tennis");
+        assertTrue(firstSport.equals(secondSport));
+    }
+
+    @Test
+    public void equals_nullObject_returnsFalse() {
+        Sport sport = new Sport("Hockey");
+        assertFalse(sport.equals(null));
+    }
+
+    @Test
+    public void equals_differentClass_returnsFalse() {
+        Sport sport = new Sport("Cricket");
+        assertFalse(sport.equals("Cricket")); // Compare with a String
+    }
+
+    @Test
+    public void equals_differentValue_returnsFalse() {
+        Sport firstSport = new Sport("Golf");
+        Sport secondSport = new Sport("Rugby");
+        assertFalse(firstSport.equals(secondSport));
+    }
+} 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,7 +1,6 @@
 package seedu.address.testutil;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -115,5 +114,4 @@ public class PersonBuilder {
     public Person build() {
         return new Person(name, phone, email, address, tags, sports);
     }
-
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,6 +1,9 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.address.model.person.Address;
@@ -8,6 +11,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Sport;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -26,6 +30,7 @@ public class PersonBuilder {
     private Email email;
     private Address address;
     private Set<Tag> tags;
+    private List<Sport> sports;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -36,6 +41,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
+        sports = new ArrayList<>();
     }
 
     /**
@@ -47,6 +53,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
+        sports = new ArrayList<>(personToCopy.getSports());
     }
 
     /**
@@ -62,6 +69,22 @@ public class PersonBuilder {
      */
     public PersonBuilder withTags(String ... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
+     * Sets the {@code List<Sport>} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withSports(List<Sport> sports) {
+        this.sports = new ArrayList<>(sports);
+        return this;
+    }
+
+    /**
+     * Adds the specified {@code Sport} to the {@code Person} that we are building.
+     */
+    public PersonBuilder withSport(String sportName) {
+        this.sports.add(new Sport(sportName));
         return this;
     }
 
@@ -90,7 +113,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, tags, sports);
     }
 
 }


### PR DESCRIPTION
Added SportTest.java to validate:
Constructor with valid/invalid inputs
toString and equals methods

Updated ParserUtilTest.java to test:
Parsing a single sport string
Parsing a collection of sport strings
Handling invalid sport inputs

Added AddSportCommandParserTest.java to cover:
Parsing valid inputs
Handling missing required fields and invalid values

Added AddSportCommandTest.java to ensure:
Constructor validation
Execution with valid inputs
Handling duplicate sports and invalid indices
equals method functionality

Updated AddressBookParserTest to include AddSportCommand parsing

Updated PersonTest to verify sport-related functionality:
Retrieving sports
Checking for a specific sport
Adding a sport to a person

Updated PersonBuilder to support creating Person objects with sports

All tests are now passing, ensuring comprehensive coverage for the new sport functionality.