### PR TITLE
FindSports command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindSportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindSportCommand.java
@@ -29,7 +29,8 @@ public class FindSportCommand extends Command {
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " badminton volleyball cricket";
-    public static final String MESSAGE_INVALID_SPORT = "Invalid sport found. Allowed sports: " + VALID_SPORTS;
+    public static final String MESSAGE_INVALID_SPORT = "Invalid sport found. Allowed sports: " + VALID_SPORTS
+            + "\nExample: " + COMMAND_WORD + " badminton volleyball cricket";;
 
 
     private final SportContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/FindSportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindSportCommand.java
@@ -1,0 +1,84 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.SportContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book who play a sport contained in any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindSportCommand extends Command {
+
+    public static final List<String> VALID_SPORTS = new ArrayList<>(Arrays.asList(
+            "soccer", "basketball", "tennis", "badminton", "cricket",
+            "baseball", "volleyball", "hockey", "rugby", "golf"
+    ));
+
+    public static final String COMMAND_WORD = "findsport";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons who play a sport contained in "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " badminton volleyball cricket";
+    public static final String MESSAGE_INVALID_SPORT = "Invalid sport found. Allowed sports: " + VALID_SPORTS;
+
+
+    private final SportContainsKeywordsPredicate predicate;
+    private final List<String> sportList;
+
+    /**
+     * Creates a FindSportCommand object to find persons who play certain sports
+     * @param predicate test if a person has sports which are contained in user input list
+     * @param sportList user input list to check for valid sports
+     */
+    public FindSportCommand(SportContainsKeywordsPredicate predicate, List<String> sportList) {
+        this.predicate = predicate;
+        this.sportList = sportList;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        // checks if any sports listed by user is not in list of valid sports
+        boolean hasInvalidSport = sportList.stream().anyMatch(sport -> VALID_SPORTS.stream()
+                .noneMatch(validSport -> StringUtil.containsWordIgnoreCase(validSport, sport)));
+
+        if (hasInvalidSport) {
+            return new CommandResult(MESSAGE_INVALID_SPORT);
+        }
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindSportCommand)) {
+            return false;
+        }
+
+        FindSportCommand otherFindSportCommand = (FindSportCommand) other;
+        return predicate.equals(otherFindSportCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.DeleteSportCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindSportCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case DeleteSportCommand.COMMAND_WORD:
             return new DeleteSportCommandParser().parse(arguments);
+
+        case FindSportCommand.COMMAND_WORD:
+            return new FindSportCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/FindSportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindSportCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.logic.commands.FindSportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.SportContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindSportCommand object.
+ */
+public class FindSportCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindSportCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindSportCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+        List<String> sportList = Arrays.asList(nameKeywords);
+
+        return new FindSportCommand(new SportContainsKeywordsPredicate(sportList), sportList);
+    }
+}

--- a/src/main/java/seedu/address/model/person/SportContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/SportContainsKeywordsPredicate.java
@@ -1,0 +1,46 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Sports} matches any of the keywords given.
+ */
+public class SportContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public SportContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getSports().stream()
+                        .anyMatch(sport -> StringUtil.containsWordIgnoreCase(sport.sportName, keyword)));
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NameContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        SportContainsKeywordsPredicate otherSportContainsKeywordsPredicate = (SportContainsKeywordsPredicate) other;
+        return keywords.equals(otherSportContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/SportContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/SportContainsKeywordsPredicate.java
@@ -31,7 +31,7 @@ public class SportContainsKeywordsPredicate implements Predicate<Person> {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof NameContainsKeywordsPredicate)) {
+        if (!(other instanceof SportContainsKeywordsPredicate)) {
             return false;
         }
 


### PR DESCRIPTION
Added Find Sport Command which allows users to find persons who play any one of the sports listed in the command

Usage Command: findsport KEYWORD [MORE KEYWORDS]
Usage Example: findsport basketball cricket baseball

Added checks to prompt user if any of the sports given are not in the valid list
findsport basketball tchoukball (returns error as tchoukball is currently not in list of existing valid sports)

Added case insensitive search