### PR TITLE
Update add command postal code

### DIFF
--- a/src/main/java/seedu/address/commons/util/LocationUtil.java
+++ b/src/main/java/seedu/address/commons/util/LocationUtil.java
@@ -15,7 +15,9 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import seedu.address.commons.exceptions.DataLoadingException;
+import seedu.address.model.person.Address;
 import seedu.address.model.person.Location;
+
 
 /**
  * A factory class to create {@code Location} objects using user input and a JSON file
@@ -76,13 +78,13 @@ public class LocationUtil {
     /**
      * Creates a {@code Location} object using the provided user address and postal code.
      *
-     * @param userInputAddress the address entered by the user.
+     * @param address the address entered by the user.
      * @param postalCode the postal code entered by the user.
      * @return a new {@code Location} object with corresponding latitude and longitude.
      * @throws IllegalArgumentException if the postal code is not found.
      */
-    public static Location createLocation(String userInputAddress, String postalCode) {
-        requireAllNonNull(userInputAddress, postalCode);
+    public static Location createLocation(Address address, String postalCode) {
+        requireAllNonNull(address, postalCode);
         requireNonNull(locationData, "Location data has not been loaded");
 
         RawLocationData rawData = locationData.get(postalCode);
@@ -93,6 +95,6 @@ public class LocationUtil {
         // Optional: Validate if the user-input address matches rawData.getAddress() if necessary.
         // For now, we use the user input for the address.
 
-        return new Location(postalCode, userInputAddress, rawData.getLatitude(), rawData.getLongitude());
+        return new Location(postalCode, address, rawData.getLatitude(), rawData.getLongitude());
     }
 }

--- a/src/main/java/seedu/address/commons/util/LocationUtil.java
+++ b/src/main/java/seedu/address/commons/util/LocationUtil.java
@@ -97,4 +97,8 @@ public class LocationUtil {
 
         return new Location(postalCode, address, rawData.getLatitude(), rawData.getLongitude());
     }
+
+    public static boolean isValidPostalCode(String postalCode) {
+        return locationData.containsKey(postalCode);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -27,6 +28,7 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_POSTAL_CODE + "POSTAL_CODE "
             + PREFIX_SPORT + "SPORT"
             + "[" + PREFIX_TAG + "TAG]... \n"
             + "Example: " + COMMAND_WORD + " "
@@ -34,6 +36,7 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_POSTAL_CODE + "120311 "
             + PREFIX_SPORT + "Badminton "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -2,10 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,7 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
 import java.util.Set;
@@ -29,15 +35,16 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_POSTAL_CODE,
-                        PREFIX_TAG, PREFIX_SPORT);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_POSTAL_CODE, PREFIX_TAG, PREFIX_SPORT);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_POSTAL_CODE, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_SPORT)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_POSTAL_CODE, PREFIX_PHONE,
+                PREFIX_EMAIL, PREFIX_SPORT) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_POSTAL_CODE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_POSTAL_CODE);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,12 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.List;
 import java.util.Set;
@@ -34,22 +29,23 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_POSTAL_CODE,
                         PREFIX_TAG, PREFIX_SPORT);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_SPORT)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_POSTAL_CODE, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_SPORT)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_POSTAL_CODE);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        String postalCode = ParserUtil.parsePostalCode(argMultimap.getValue(PREFIX_POSTAL_CODE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         List<Sport> sports = ParserUtil.parseSports(argMultimap.getAllValues(PREFIX_SPORT));
-        Person person = new Person(name, phone, email, address, tagList, sports);
+        Person person = new Person(name, phone, email, address, postalCode, tagList, sports);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,6 +10,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_POSTAL_CODE = new Prefix("pc/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_SPORT = new Prefix("s/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.LocationUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
@@ -82,6 +83,21 @@ public class ParserUtil {
             throw new ParseException(Address.MESSAGE_CONSTRAINTS);
         }
         return new Address(trimmedAddress);
+    }
+
+    /**
+     * Parses a {@code String postalCode} into a {@code String}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code postalCode} is invalid.
+     */
+    public static String parsePostalCode(String postalCode) throws ParseException {
+        requireNonNull(postalCode);
+        String trimmedPostalCode = postalCode.trim();
+        if (trimmedPostalCode.isEmpty() || !LocationUtil.isValidPostalCode(trimmedPostalCode)) {
+            throw new ParseException(Address.MESSAGE_CONSTRAINTS);
+        }
+        return trimmedPostalCode;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Location.java
+++ b/src/main/java/seedu/address/model/person/Location.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 public class Location {
 
     private final String postalCode;
-    private final String address;
+    private final Address address;
     private final double latitude;
     private final double longitude;
 
@@ -25,7 +25,7 @@ public class Location {
      * @param latitude the latitude coordinate.
      * @param longitude the longitude coordinate.
      */
-    public Location(String postalCode, String address, double latitude, double longitude) {
+    public Location(String postalCode, Address address, double latitude, double longitude) {
         requireAllNonNull(postalCode, address);
         this.postalCode = postalCode;
         this.address = address;
@@ -37,7 +37,7 @@ public class Location {
         return postalCode;
     }
 
-    public String getAddress() {
+    public Address getAddress() {
         return address;
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -26,7 +26,6 @@ public class Person {
 
     // Data fields
     private final Address address;
-
     private final Location location;
     private final Set<Tag> tags = new HashSet<>();
     private final List<Sport> sports = new ArrayList<>();
@@ -42,7 +41,7 @@ public class Person {
         this.address = address;
         this.tags.addAll(tags);
         this.sports.addAll(sports);
-        this.location = LocationUtil.createLocation(address.toString(), postalCode);
+        this.location = LocationUtil.createLocation(address, postalCode);
     }
 
     /**
@@ -56,7 +55,7 @@ public class Person {
         this.address = address;
         this.tags.addAll(tags);
         this.sports.addAll(sports);
-        this.location = null;
+        this.location = LocationUtil.createLocation(address, "018935"); //default location
     }
     /**
      * Constructor for Person class returns an immutable Person object. Left here for compatibility.
@@ -69,7 +68,7 @@ public class Person {
         this.address = address;
         this.tags.addAll(tags);
         this.sports.addAll(Collections.emptyList());
-        this.location = null;
+        this.location = LocationUtil.createLocation(address, "018935"); //default location
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -87,6 +87,10 @@ public class Person {
         return address;
     }
 
+    public String getPostalCode() {
+        return location.getPostalCode();
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.commons.util.LocationUtil;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -25,11 +26,27 @@ public class Person {
 
     // Data fields
     private final Address address;
+
+    private final Location location;
     private final Set<Tag> tags = new HashSet<>();
     private final List<Sport> sports = new ArrayList<>();
 
     /**
      * Constructor for Person class returns an immutable Person object.
+     */
+    public Person(Name name, Phone phone, Email email, Address address, String postalCode, Set<Tag> tags, List<Sport> sports) {
+        requireAllNonNull(name, phone, email, address, tags, sports);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        this.sports.addAll(sports);
+        this.location = LocationUtil.createLocation(address.toString(), postalCode);
+    }
+
+    /**
+     * Constructor for Person class returns an immutable Person object. Left here for compatibility.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, List<Sport> sports) {
         requireAllNonNull(name, phone, email, address, tags, sports);
@@ -39,9 +56,10 @@ public class Person {
         this.address = address;
         this.tags.addAll(tags);
         this.sports.addAll(sports);
+        this.location = null;
     }
     /**
-     * Constructor for Person class returns an immutable Person object.
+     * Constructor for Person class returns an immutable Person object. Left here for compatibility.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
@@ -51,6 +69,7 @@ public class Person {
         this.address = address;
         this.tags.addAll(tags);
         this.sports.addAll(Collections.emptyList());
+        this.location = null;
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -9,8 +9,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.commons.util.LocationUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
 import seedu.address.model.tag.Tag;
 
 /**
@@ -33,7 +34,8 @@ public class Person {
     /**
      * Constructor for Person class returns an immutable Person object.
      */
-    public Person(Name name, Phone phone, Email email, Address address, String postalCode, Set<Tag> tags, List<Sport> sports) {
+    public Person(Name name, Phone phone, Email email, Address address, String postalCode, Set<Tag> tags,
+                  List<Sport> sports) {
         requireAllNonNull(name, phone, email, address, tags, sports);
         this.name = name;
         this.phone = phone;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -11,7 +11,6 @@ import java.util.Set;
 
 import seedu.address.commons.util.LocationUtil;
 import seedu.address.commons.util.ToStringBuilder;
-
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/test/java/seedu/address/commons/util/LocationUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/LocationUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -51,5 +52,11 @@ public class LocationUtilTest {
 
         // Optionally, assert that the average creation time is below a desired threshold.
         assertTrue(avgCreationTime < 100_000, "Average creation time is too high: " + avgCreationTime + " ns.");
+    }
+
+    @Test
+    public void testisValidPostalCodeValid() {
+        assertTrue(LocationUtil.isValidPostalCode("018906"));
+        assertFalse(LocationUtil.isValidPostalCode("01890"));
     }
 }

--- a/src/test/java/seedu/address/commons/util/LocationUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/LocationUtilTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Address;
 import seedu.address.model.person.Location;
 
 public class LocationUtilTest {
@@ -29,7 +30,7 @@ public class LocationUtilTest {
     @Test
     public void testLocationCreationPerformance() {
         // Example user input.
-        String userAddress = "5 STRAITS VIEW THE HEART SINGAPORE 018935";
+        Address userAddress = new Address("5 STRAITS VIEW THE HEART SINGAPORE 018935");
         String postalCode = "018935";
 
         // Warm-up: Create one Location to ensure any caching or static initialization is complete.

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -11,8 +11,8 @@ import static seedu.address.logic.commands.CommandTestUtil.POSTAL_CODE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_BADMINTON;
 import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_CRICKET;
 import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_VOLLEYBALL;
-import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.AMY;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -3,9 +3,16 @@ package seedu.address.logic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.POSTAL_CODE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_BADMINTON;
+import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_CRICKET;
+import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_VOLLEYBALL;
 import static seedu.address.testutil.TypicalPersons.AMY;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -3,13 +3,7 @@ package seedu.address.logic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_BADMINTON;
-import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_CRICKET;
-import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_VOLLEYBALL;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
 
@@ -169,7 +163,7 @@ public class LogicManagerTest {
 
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + SPORTS_DESC_BADMINTON + SPORTS_DESC_CRICKET
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + POSTAL_CODE_DESC_AMY + SPORTS_DESC_BADMINTON + SPORTS_DESC_CRICKET
                 + SPORTS_DESC_VOLLEYBALL;
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -2,7 +2,13 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -2,12 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -35,6 +30,9 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
+
+    public static final String VALID_POSTAL_CODE_AMY = "018906";
+    public static final String VALID_POSTAL_CODE_BOB = "018935";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_SPORTS_VOLLEYBALL = "volleyball";
@@ -48,6 +46,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String POSTAL_CODE_DESC_AMY = " " + PREFIX_POSTAL_CODE + VALID_POSTAL_CODE_AMY;
+    public static final String POSTAL_CODE_DESC_BOB = " " + PREFIX_POSTAL_CODE + VALID_POSTAL_CODE_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String SPORTS_DESC_VOLLEYBALL = " " + PREFIX_SPORT + VALID_SPORTS_VOLLEYBALL;
@@ -59,6 +59,7 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
+    public static final String INVALID_POSTAL_CODE_DESC = " " + PREFIX_POSTAL_CODE; // empty postal code not allowed
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,38 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_BADMINTON;
-import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_CRICKET;
-import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_VOLLEYBALL;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_BADMINTON;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_VOLLEYBALL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -60,7 +30,7 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + POSTAL_CODE_DESC_BOB + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, new AddCommand(expectedPerson));
 
 
         // multiple tags - all accepted
@@ -68,15 +38,15 @@ public class AddCommandParserTest {
                 .withSports(VALID_SPORTS_BADMINTON, VALID_SPORTS_VOLLEYBALL)
                 .build();
         assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND
-                        + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON + SPORTS_DESC_VOLLEYBALL,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + POSTAL_CODE_DESC_BOB
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON + SPORTS_DESC_VOLLEYBALL,
                 new AddCommand(expectedPersonMultipleTags));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON;
+                + ADDRESS_DESC_BOB + POSTAL_CODE_DESC_BOB + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
@@ -94,11 +64,16 @@ public class AddCommandParserTest {
         assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
 
+        // multiple postal codes
+        assertParseFailure(parser, POSTAL_CODE_DESC_AMY + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_POSTAL_CODE));
+
         // multiple fields repeated
         assertParseFailure(parser,
                 validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
-                        + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
+                        + POSTAL_CODE_DESC_AMY + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_POSTAL_CODE,
+                        PREFIX_EMAIL, PREFIX_PHONE));
 
         // invalid value followed by valid value
 
@@ -118,6 +93,10 @@ public class AddCommandParserTest {
         assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
 
+        // invalid postal code
+        assertParseFailure(parser, INVALID_POSTAL_CODE_DESC + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_POSTAL_CODE));
+
         // valid value followed by invalid value
 
         // invalid name
@@ -135,6 +114,10 @@ public class AddCommandParserTest {
         // invalid address
         assertParseFailure(parser, validExpectedPersonString + INVALID_ADDRESS_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+
+        // invalid address
+        assertParseFailure(parser, validExpectedPersonString + INVALID_POSTAL_CODE_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_POSTAL_CODE));
     }
 
     @Test
@@ -142,7 +125,7 @@ public class AddCommandParserTest {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                        + SPORTS_DESC_BADMINTON + SPORTS_DESC_CRICKET + SPORTS_DESC_VOLLEYBALL,
+                        + POSTAL_CODE_DESC_AMY + SPORTS_DESC_BADMINTON + SPORTS_DESC_CRICKET + SPORTS_DESC_VOLLEYBALL,
                 new AddCommand(expectedPerson));
     }
 
@@ -152,54 +135,63 @@ public class AddCommandParserTest {
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                        + VALID_SPORTS_BADMINTON, expectedMessage);
+                + POSTAL_CODE_DESC_BOB + VALID_SPORTS_BADMINTON, expectedMessage);
 
         // missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                        + VALID_SPORTS_BADMINTON, expectedMessage);
+                + POSTAL_CODE_DESC_BOB + VALID_SPORTS_BADMINTON, expectedMessage);
 
         // missing email prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB
-                        + VALID_SPORTS_BADMINTON, expectedMessage);
+                + POSTAL_CODE_DESC_BOB + VALID_SPORTS_BADMINTON, expectedMessage);
 
         // missing address prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB
-                        + VALID_SPORTS_BADMINTON, expectedMessage);
+                + POSTAL_CODE_DESC_BOB + VALID_SPORTS_BADMINTON, expectedMessage);
+
+        // missing postal code prefix
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + VALID_POSTAL_CODE_BOB + VALID_SPORTS_BADMINTON, expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB
-                        + VALID_SPORTS_BADMINTON, expectedMessage);
+                + VALID_POSTAL_CODE_BOB + VALID_SPORTS_BADMINTON, expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Name.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Phone.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Email.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Address.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Address.MESSAGE_CONSTRAINTS);
+
+        // invalid postal code (we can add more tests here as we go,
+        // since postal code can be invalid in many ways, and this only accounts for empty postal code)
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
+                + INVALID_POSTAL_CODE_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Address.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND + SPORTS_DESC_BADMINTON, Tag.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND + SPORTS_DESC_BADMINTON, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                        + SPORTS_DESC_BADMINTON, Name.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + SPORTS_DESC_BADMINTON, Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
+                        + POSTAL_CODE_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,8 +1,43 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_POSTAL_CODE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.POSTAL_CODE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.POSTAL_CODE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_BADMINTON;
+import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_CRICKET;
+import static seedu.address.logic.commands.CommandTestUtil.SPORTS_DESC_VOLLEYBALL;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POSTAL_CODE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_BADMINTON;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_VOLLEYBALL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -30,7 +65,8 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + POSTAL_CODE_DESC_BOB + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + POSTAL_CODE_DESC_BOB + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
+                new AddCommand(expectedPerson));
 
 
         // multiple tags - all accepted
@@ -162,28 +198,34 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Name.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
+                Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Phone.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
+                Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Email.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
+                Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Address.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
+                Address.MESSAGE_CONSTRAINTS);
 
         // invalid postal code (we can add more tests here as we go,
         // since postal code can be invalid in many ways, and this only accounts for empty postal code)
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + INVALID_POSTAL_CODE_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON, Address.MESSAGE_CONSTRAINTS);
+                + INVALID_POSTAL_CODE_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
+                Address.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + POSTAL_CODE_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND + SPORTS_DESC_BADMINTON, Tag.MESSAGE_CONSTRAINTS);
+                + POSTAL_CODE_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND + SPORTS_DESC_BADMINTON,
+                Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
@@ -191,7 +233,8 @@ public class AddCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + POSTAL_CODE_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + SPORTS_DESC_BADMINTON,
+                        + POSTAL_CODE_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND
+                        + SPORTS_DESC_BADMINTON,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -27,12 +27,17 @@ public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
+
+    private static final String INVALID_POSTAL_CODE = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
+
+    private static final String VALID_POSTAL_CODE = "018906";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
@@ -131,6 +136,29 @@ public class ParserUtilTest {
         String addressWithWhitespace = WHITESPACE + VALID_ADDRESS + WHITESPACE;
         Address expectedAddress = new Address(VALID_ADDRESS);
         assertEquals(expectedAddress, ParserUtil.parseAddress(addressWithWhitespace));
+    }
+
+    @Test
+    public void parsePostalCode_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parsePostalCode((String) null));
+    }
+
+    @Test
+    public void parsePostalCode_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePostalCode(INVALID_POSTAL_CODE));
+    }
+
+    @Test
+    public void parsePostalCode_validValueWithoutWhitespace_returnsAddress() throws Exception {
+        String expectedPostalCode = VALID_POSTAL_CODE;
+        assertEquals(expectedPostalCode, ParserUtil.parsePostalCode(VALID_POSTAL_CODE));
+    }
+
+    @Test
+    public void parsePostalCode_validValueWithWhitespace_returnsTrimmedPostalCode() throws Exception {
+        String postalCodeWithWhitespace = WHITESPACE + VALID_POSTAL_CODE + WHITESPACE;
+        String expectedPostalCode = VALID_POSTAL_CODE;
+        assertEquals(expectedPostalCode, ParserUtil.parsePostalCode(postalCodeWithWhitespace));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -22,7 +22,9 @@ public class PersonBuilder {
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
-    public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_ADDRESS = "1 STRAITS BOULEVARD SINGAPORE CHINESE CULTURAL CENTRE SINGAPORE";
+
+    public static final String DEFAULT_POSTAL_CODE = "018906";
 
     public static final List<Sport> DEFAULT_SPORTS = List.of(new Sport("badminton"));
 
@@ -30,6 +32,8 @@ public class PersonBuilder {
     private Phone phone;
     private Email email;
     private Address address;
+
+    private String postalCode;
     private Set<Tag> tags;
     private List<Sport> sports;
 
@@ -41,6 +45,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
+        postalCode = DEFAULT_POSTAL_CODE;
         tags = new HashSet<>();
         sports = new ArrayList<>(DEFAULT_SPORTS);
     }
@@ -53,6 +58,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
+        postalCode = personToCopy.getPostalCode();
         tags = new HashSet<>(personToCopy.getTags());
         sports = new ArrayList<>(personToCopy.getSports());
     }
@@ -105,6 +111,14 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code PostalCode} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+        return this;
+    }
+
+    /**
      * Sets the {@code Phone} of the {@code Person} that we are building.
      */
     public PersonBuilder withPhone(String phone) {
@@ -121,6 +135,6 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, phone, email, address, tags, sports);
+        return new Person(name, phone, email, address, postalCode, tags, sports);
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -3,8 +3,8 @@ package seedu.address.testutil;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -1,9 +1,9 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -37,6 +38,7 @@ public class PersonUtil {
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
+        sb.append(PREFIX_POSTAL_CODE + person.getPostalCode() + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -1,19 +1,5 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_BADMINTON;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_CRICKET;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_VOLLEYBALL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -21,43 +7,45 @@ import java.util.List;
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
 
+import static seedu.address.logic.commands.CommandTestUtil.*;
+
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.
  */
 public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
-            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+            .withAddress("123, Jurong West Ave 6, #08-111").withPostalCode("018906").withEmail("alice@example.com")
             .withPhone("94351253")
             .withTags("friends").withSports("volleyball").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
-            .withAddress("311, Clementi Ave 2, #02-25")
+            .withAddress("311, Clementi Ave 2, #02-25").withPostalCode("120311")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").withSports("cricket").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").withSports("basketball").build();
+            .withEmail("heinz@example.com").withAddress("wall street").withPostalCode("018907").withSports("basketball").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street")
-            .withSports("tennis").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street").withPostalCode("018910").
+            withSports("tennis").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").withSports("rugby").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withPostalCode("018916").withSports("rugby").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").withSports("soccer").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo").withPostalCode("018925").withSports("soccer").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").withSports("baseball").build();
+            .withEmail("anna@example.com").withAddress("4th street").withPostalCode("018926").withSports("baseball").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").withSports("volleyball").build();
+            .withEmail("stefan@example.com").withAddress("little india").withPostalCode("018927").withSports("volleyball").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").withSports("basketball").build();
+            .withEmail("hans@example.com").withAddress("chicago ave").withPostalCode("018928").withSports("basketball").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND)
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withPostalCode(VALID_POSTAL_CODE_AMY).withTags(VALID_TAG_FRIEND)
             .withSports(VALID_SPORTS_BADMINTON, VALID_SPORTS_CRICKET, VALID_SPORTS_VOLLEYBALL).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withPostalCode(VALID_POSTAL_CODE_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .withSports(VALID_SPORTS_BADMINTON, VALID_SPORTS_CRICKET)
             .build();
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -1,5 +1,22 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POSTAL_CODE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POSTAL_CODE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_BADMINTON;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_CRICKET;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_VOLLEYBALL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -7,7 +24,6 @@ import java.util.List;
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
 
-import static seedu.address.logic.commands.CommandTestUtil.*;
 
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.
@@ -23,30 +39,37 @@ public class TypicalPersons {
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").withSports("cricket").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").withPostalCode("018907").withSports("basketball").build();
+            .withEmail("heinz@example.com").withAddress("wall street").withPostalCode("018907").withSports("basketball")
+            .build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withPostalCode("018910").
-            withSports("tennis").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street").withPostalCode("018910").withSports("tennis")
+            .withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").withPostalCode("018916").withSports("rugby").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withPostalCode("018916").withSports("rugby")
+            .build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").withPostalCode("018925").withSports("soccer").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo").withPostalCode("018925").withSports("soccer")
+            .build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").withPostalCode("018926").withSports("baseball").build();
+            .withEmail("anna@example.com").withAddress("4th street").withPostalCode("018926").withSports("baseball")
+            .build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").withPostalCode("018927").withSports("volleyball").build();
+            .withEmail("stefan@example.com").withAddress("little india").withPostalCode("018927")
+            .withSports("volleyball").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").withPostalCode("018928").withSports("basketball").build();
+            .withEmail("hans@example.com").withAddress("chicago ave").withPostalCode("018928").withSports("basketball")
+            .build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withPostalCode(VALID_POSTAL_CODE_AMY).withTags(VALID_TAG_FRIEND)
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withPostalCode(VALID_POSTAL_CODE_AMY)
+            .withTags(VALID_TAG_FRIEND)
             .withSports(VALID_SPORTS_BADMINTON, VALID_SPORTS_CRICKET, VALID_SPORTS_VOLLEYBALL).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withPostalCode(VALID_POSTAL_CODE_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .withSports(VALID_SPORTS_BADMINTON, VALID_SPORTS_CRICKET)
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withPostalCode(VALID_POSTAL_CODE_BOB)
+            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withSports(VALID_SPORTS_BADMINTON, VALID_SPORTS_CRICKET)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -6,16 +6,15 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_POSTAL_CODE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_POSTAL_CODE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POSTAL_CODE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POSTAL_CODE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_BADMINTON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_CRICKET;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SPORTS_VOLLEYBALL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
### Add command now can take in postal code

Postal Code is simply a String

1. Prefix for postal code is pc/ , as agreed upon in our last meeting.
2. Person now has location field, which is composed of an Address object, and a String postalCode (we can consider removing the address field and relying solely on the location field, however, I discourage this it will take a lot of work and I don't see it adding much value to the codebase.
3. Check for validity of user inputted postal code against @SomneelSaha2004 's `postal_code_data.json` file occurs during parsing in `ParserUtil.parsePostalCode`.
4. `AddCommandParserTest` only tests for empty postal code i.e " ", however there are many more ways for postal codes to be invalid, such as being of wrong length, containing characters other than integers, postal code being in valid format but not existing in json file **@isaacchua0309 you can go ahead and do this to complete your pull request for v1.3**.
5. `AddCommandParserTest` and `AddCommandTest` and the utilities they depend on have all been updated to include and work with postal codes.

I'm gonna crash