### PR TITLE
Fix add group command make delete group command

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -32,6 +33,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
+
+    /** Returns an unmodifiable view of the filtered list of groups */
+    ObservableList<Group> getFilteredGroupList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -15,6 +15,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 
@@ -66,11 +67,16 @@ public class LogicManager implements Logic {
         return model.getAddressBook();
     }
 
+
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return model.getFilteredPersonList();
     }
 
+    @Override
+    public ObservableList<Group> getFilteredGroupList() {
+        return model.getFilteredGroupList();
+    }
     @Override
     public Path getAddressBookFilePath() {
         return model.getAddressBookFilePath();

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -15,6 +16,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_GROUP_DISPLAYED_INDEX = "The group index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
@@ -46,6 +48,17 @@ public class Messages {
                 .append(person.getAddress())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
+        return builder.toString();
+    }
+
+    /**
+     * Formats the {@code group} for display to the user.
+     */
+    public static String format(Group group) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(group.getGroupName())
+                .append("; members: ");
+        group.getMembers().forEach(builder::append);
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
@@ -16,26 +19,42 @@ public class AddGroupCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New group added: %1$s";
     public static final String MESSAGE_DUPLICATE_GROUP = "This group already exists in the address book";
 
-    private final String groupName;
+    private final Group group;
 
-    public AddGroupCommand(String groupName) {
-        this.groupName = groupName;
+    /**
+     * Creates an AddCommand to add the specified {@code Group}
+     */
+    public AddGroupCommand(Group group) {
+        requireNonNull(group);
+        this.group = group;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        if (model.hasGroup(groupName)) {
+        requireNonNull(model);
+
+        if (model.hasGroup(group)) {
             throw new CommandException(MESSAGE_DUPLICATE_GROUP);
         }
 
-        Group group = new Group(groupName);
         model.addGroup(group);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, groupName));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, group));
     }
 
     @Override
     public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
         return other instanceof AddGroupCommand
-                && ((AddGroupCommand) other).groupName.equals(this.groupName);
+                && ((AddGroupCommand) other).group.equals(this.group);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("group", group)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.group.Group;
+
+/**
+ * Deletes a group identified using it's displayed index from the address book.
+ */
+public class DeleteGroupCommand extends Command {
+    public static final String COMMAND_WORD = "deletegroup";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the group identified by the index number used in the displayed group list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 2";
+
+    public static final String MESSAGE_DELETE_GROUP_SUCCESS = "Deleted Group: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteGroupCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Group> lastShownList = model.getFilteredGroupList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_GROUP_DISPLAYED_INDEX);
+        }
+
+        Group groupToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteGroup(groupToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_GROUP_SUCCESS, Messages.format(groupToDelete)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteGroupCommand)) {
+            return false;
+        }
+
+        DeleteGroupCommand otherDeleteGroupCommand = (DeleteGroupCommand) other;
+        return targetIndex.equals(otherDeleteGroupCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
 import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
 
 /**
  * Parses input arguments and creates a new AddGroupCommand object.
@@ -25,12 +26,8 @@ public class AddGroupCommandParser implements Parser<AddGroupCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddGroupCommand.MESSAGE_USAGE));
         }
 
-        String groupName = argMultimap.getValue(PREFIX_GROUP_NAME).get().trim();
+        Group group = ParserUtil.parseGroup(argMultimap.getValue(PREFIX_GROUP_NAME).get());
 
-        if (groupName.isEmpty()) {
-            throw new ParseException("Group name cannot be empty.");
-        }
-
-        return new AddGroupCommand(groupName);
+        return new AddGroupCommand(group);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.AddSportCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteGroupCommand;
 import seedu.address.logic.commands.DeleteSportCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -92,6 +93,9 @@ public class AddressBookParser {
 
         case AddGroupCommand.COMMAND_WORD:
             return new AddGroupCommandParser().parse(arguments);
+
+        case DeleteGroupCommand.COMMAND_WORD:
+            return new DeleteGroupCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteGroupCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteGroupCommand object
+ */
+public class DeleteGroupCommandParser implements Parser<DeleteGroupCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteGroupCommand
+     * and returns a DeleteGroupCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteGroupCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteGroupCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteGroupCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.LocationUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -116,6 +117,22 @@ public class ParserUtil {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
         return new Email(trimmedEmail);
+    }
+
+    /**
+     * Parses a {@code String groupName} into an {@code Group}.
+     * Leading and trailing whitespaces will be trimmed.
+     * Name class will be used to validate the name of the group
+     * @throws ParseException if the name is not valid as defined in Name class
+     */
+    public static Group parseGroup(String groupName) throws ParseException {
+        requireNonNull(groupName);
+        String trimmedGroupName = groupName.trim();
+        if (!Name.isValidName(trimmedGroupName)) {
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+        }
+        Name namedGroup = new Name(groupName);
+        return new Group(namedGroup);
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -53,15 +53,6 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Replaces the contents of the group list with {@code groupList}.
-     * {@code groupList} must not contain duplicate group names.
-     */
-    public void setGroups(UniqueGroupList groupList) {
-        requireNonNull(groupList);
-        this.groups.setGroups(groupList);
-    }
-
-    /**
      * Replaces the contents of the group list with {@code groups}.
      * {@code groups} must not contain duplicate group names.
      */
@@ -141,11 +132,18 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param groupName The name of the group to check.
      * @return true if the group exists, false otherwise.
      */
-    public boolean hasGroup(String groupName) {
+    public boolean hasGroup(Group groupName) {
         requireNonNull(groupName);
         return groups.contains(groupName);
     }
 
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeGroup(Group key) {
+        groups.remove(key);
+    }
 
     //// util methods
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -86,13 +86,22 @@ public interface Model {
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
 
+    /** Returns an unmodifiable view of the filtered group list */
+    ObservableList<Group> getFilteredGroupList();
+
+    /**
+     * Updates the filter of the filtered group list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredGroupList(Predicate<Group> predicate);
+
     /**
      * Returns true if a group with the given {@code groupName} exists in the address book.
      *
-     * @param groupName The name of the group to check.
+     * @param groupName The identity of the group to check.
      * @return true if the group exists, false otherwise.
      */
-    boolean hasGroup(String groupName);
+    boolean hasGroup(Group groupName);
 
     /**
      * Adds a new group to the address book.
@@ -102,6 +111,11 @@ public interface Model {
      */
     void addGroup(Group group);
 
+    /**
+     * Deletes the given group.
+     * The group must exist in the address book.
+     */
+    void deleteGroup(Group target);
     /**
      * Returns the list of all groups in the address book.
      * The returned list is unmodifiable.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,6 +24,8 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
+    private final FilteredList<Group> filteredGroups;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -35,6 +37,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredGroups = new FilteredList<>(this.addressBook.getGroupList());
     }
 
     public ModelManager() {
@@ -113,9 +116,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasGroup(String groupName) {
-        requireNonNull(groupName);
-        return addressBook.hasGroup(groupName);
+    public boolean hasGroup(Group group) {
+        requireNonNull(group);
+        return addressBook.hasGroup(group);
+    }
+
+    @Override
+    public void deleteGroup(Group target) {
+        addressBook.removeGroup(target);
     }
 
     @Override
@@ -129,7 +137,7 @@ public class ModelManager implements Model {
         return addressBook.getGroupList();
     }
 
-    //=========== Filtered Person List Accessors =============================================================
+    //=========== Filtered Person and Group List Accessors =============================================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of
@@ -144,6 +152,21 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Group} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Group> getFilteredGroupList() {
+        return filteredGroups;
+    }
+
+    @Override
+    public void updateFilteredGroupList(Predicate<Group> predicate) {
+        requireNonNull(predicate);
+        filteredGroups.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,6 +1,9 @@
 // Represents a named group of UniquePersonList
 package seedu.address.model.group;
 
+import java.util.List;
+
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -9,7 +12,7 @@ import seedu.address.model.person.UniquePersonList;
  * Each group has a unique group name and a {@link UniquePersonList} as members.
  */
 public class Group {
-    private final String groupName;
+    private final Name groupName;
     private final UniquePersonList members;
 
     /**
@@ -17,12 +20,24 @@ public class Group {
      *
      * @param groupName The name of the group.
      */
-    public Group(String groupName) {
+    public Group(Name groupName) {
         this.groupName = groupName;
         this.members = new UniquePersonList();
     }
 
-    public String getGroupName() {
+    /**
+     * Constructs a {@code Group} with the given name and an empty list of members.
+     * @param groupName The name of the group.
+     * @param members List of members
+     */
+    public Group(Name groupName, List<Person> members) {
+        this.groupName = groupName;
+        UniquePersonList toAddMembers = new UniquePersonList();
+        toAddMembers.setPersons(members);
+        this.members = toAddMembers;
+    }
+
+    public Name getGroupName() {
         return groupName;
     }
 
@@ -38,6 +53,23 @@ public class Group {
         members.remove(person);
     }
 
+    /**
+     * Returns true if both groups have the same name.
+     * Defines weaker notion of equality between two groups to ensure that no two groups of same name exist
+     */
+    public boolean isSameGroup(Group otherGroup) {
+        if (otherGroup == this) {
+            return true;
+        }
+
+        return otherGroup != null
+                && otherGroup.getGroupName().equals(getGroupName());
+    }
+
+    /**
+     * Returns true if both groups have the same name and data fields
+     * Defines stronger notion of equality between two groups
+     */
     @Override
     public boolean equals(Object other) {
         return other instanceof Group

--- a/src/main/java/seedu/address/model/group/exceptions/DuplicateGroupException.java
+++ b/src/main/java/seedu/address/model/group/exceptions/DuplicateGroupException.java
@@ -1,4 +1,4 @@
-package seedu.address.model.person.exceptions;
+package seedu.address.model.group.exceptions;
 
 /**
  * Signals that the operation will result in duplicate Groups (Groups are

--- a/src/main/java/seedu/address/model/group/exceptions/GroupNotFoundException.java
+++ b/src/main/java/seedu/address/model/group/exceptions/GroupNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.group.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified group.
+ */
+public class GroupNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
@@ -1,0 +1,75 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.group.Group;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Sport;
+import seedu.address.model.tag.Tag;
+
+public class JsonAdaptedGroup {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Group's %s field is missing!";
+
+    private final String name;
+
+    private final List<JsonAdaptedPerson> members = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedGroup} with the given group details.
+     */
+    @JsonCreator
+    public JsonAdaptedGroup(@JsonProperty("name") String name,
+                             @JsonProperty("members") List<JsonAdaptedPerson> members) {
+        this.name = name;
+        if (members != null) {
+            this.members.addAll(members);
+        }
+    }
+
+    /**
+     * Converts a given {@code Group} into this class for Jackson use.
+     */
+    public JsonAdaptedGroup(Group source) {
+        name = source.getGroupName().fullName;
+        members.addAll(source.getMembers().asUnmodifiableObservableList().stream()
+                .map(JsonAdaptedPerson::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this JSON-friendly adapted person object into the model's {@code Person} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     */
+    public Group toModelType() throws IllegalValueException {
+
+        final List<Person> persons = new ArrayList<>();
+        for (JsonAdaptedPerson person : members) {
+            persons.add(person.toModelType());
+        }
+
+        if (name == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        return new Group(modelName, persons);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
@@ -1,9 +1,7 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -11,14 +9,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.group.Group;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.person.Sport;
-import seedu.address.model.tag.Tag;
 
+/**
+ * JSON-friendly version of {@link Group}.
+ */
 public class JsonAdaptedGroup {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Group's %s field is missing!";

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -21,14 +22,20 @@ class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 
+    public static final String MESSAGE_DUPLICATE_GROUP = "Group list contains duplicate group(s).";
+
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+
+    private final List<JsonAdaptedGroup> groups = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                       @JsonProperty("groups") List<JsonAdaptedGroup> groups) {
         this.persons.addAll(persons);
+        this.groups.addAll(groups);
     }
 
     /**
@@ -38,6 +45,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        groups.addAll(source.getGroupList().stream().map(JsonAdaptedGroup::new).collect(Collectors.toList()));
     }
 
     /**
@@ -53,6 +61,14 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
             addressBook.addPerson(person);
+        }
+
+        for (JsonAdaptedGroup jsonAdaptedGroup : groups) {
+            Group group = jsonAdaptedGroup.toModelType();
+            if (addressBook.hasGroup(group)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_GROUP);
+            }
+            addressBook.addGroup(group);
         }
         return addressBook;
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -15,5 +15,6 @@
     "postalCode": "018906",
     "tags": [ ],
     "sports": [ ]
-  } ]
+  } ],
+  "groups" : []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -7,5 +7,6 @@
     "postalCode": "018906",
     "tags": [ ],
     "sports": [ ]
-  } ]
+  } ],
+  "groups" : []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -56,5 +56,6 @@
     "postalCode" : "018926",
     "tags" : [ ],
     "sports": [ "baseball" ]
-  } ]
+  } ],
+  "groups" : []
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -146,6 +146,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void deleteGroup(Group target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setPerson(Person target, Person editedPerson) {
             throw new AssertionError("This method should not be called.");
         }
@@ -161,6 +166,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Group> getFilteredGroupList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredGroupList(Predicate<Group> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Group> getGroupList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -171,7 +186,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean hasGroup(String groupName) {
+        public boolean hasGroup(Group groupName) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
### AddGroupCommand Changes
Changed Method Parameters from `String groupName` to `Group groupName`
Implemented JsonAdaptedGroup and updated JsonSerializableAddressBook to allow write, delete and store operations to track group 
Implemented various methods in Model, ModelManager, Logic, LogicManager

### Group Class changes
Changed groupName to be of type Name instead of String which avails validation checking present in Name class

### DeleteGroupCommand Implementation
Implemented DeleteGroupCommand and its respective components


### Yet to Implement

- Cannot view yet
- Cannot add persons to group yet (code to support the storing of person in group has been added via JsonAdaptedGroup)
- Yet to include tests for new functions