### PR TITLE
Findsport with distance sort

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/FindSportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindSportCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
 
 import java.util.List;
 
@@ -10,9 +12,10 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Sport;
 import seedu.address.model.person.SportContainsKeywordsPredicate;
 
+
 /**
  * Finds and lists all persons in address book who play a sport contained in any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindSportCommand extends Command {
 
@@ -20,30 +23,39 @@ public class FindSportCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons who play a sport contained in "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " badminton volleyball cricket";
+            + "Parameters: "
+            + "[" + PREFIX_POSTAL_CODE + "POSTAL_CODE] "
+            + PREFIX_SPORT + "SPORT_KEYWORD "
+            + PREFIX_SPORT + "[MORE_SPORT_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_POSTAL_CODE + "018906 "
+            + PREFIX_SPORT + "badminton "
+            + PREFIX_SPORT + "volleyball "
+            + PREFIX_SPORT + "cricket";
     public static final String MESSAGE_INVALID_SPORT = "Invalid sport found. Allowed sports: " + Sport.VALID_SPORTS
-            + "\nExample: " + COMMAND_WORD + " badminton volleyball cricket";
+            + "\nExample: " + COMMAND_WORD
+            + PREFIX_SPORT + "badminton "
+            + PREFIX_SPORT + "volleyball "
+            + PREFIX_SPORT + "cricket";
 
-
-    private final SportContainsKeywordsPredicate predicate;
-    private final List<String> sportList;
+    protected final SportContainsKeywordsPredicate predicate;
+    protected final List<String> sportKeywordList;
 
     /**
      * Creates a FindSportCommand object to find persons who play certain sports
      * @param predicate test if a person has sports which are contained in user input list
-     * @param sportList user input list to check for valid sports
+     * @param sportKeywordList user input list to check for valid sports
      */
-    public FindSportCommand(SportContainsKeywordsPredicate predicate, List<String> sportList) {
+    public FindSportCommand(SportContainsKeywordsPredicate predicate, List<String> sportKeywordList) {
         this.predicate = predicate;
-        this.sportList = sportList;
+        this.sportKeywordList = sportKeywordList;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         // Use Sport.isValidSport to validate each sport
-        boolean hasInvalidSport = sportList.stream()
+        boolean hasInvalidSport = sportKeywordList.stream()
                 .anyMatch(sport -> !Sport.isValidSport(sport));
 
         if (hasInvalidSport) {

--- a/src/main/java/seedu/address/logic/commands/FindSportSortByDistanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindSportSortByDistanceCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.util.LocationUtil;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Location;
+import seedu.address.model.person.Sport;
+import seedu.address.model.person.SportContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book who play a sport contained in any of the argument keywords.
+ * Then sorts them by distance from the address at the provided postal code.
+ * Keyword matching is case-insensitive.
+ */
+public class FindSportSortByDistanceCommand extends FindSportCommand {
+
+    public final String postalCode;
+    public final Location locationToBeCompared;
+    /**
+     * Creates a FindSportCommand object to find persons who play certain sports
+     *
+     * @param predicate        test if a person has sports which are contained in user input list
+     * @param sportKeywordList user input list to check for valid sports
+     */
+    public FindSportSortByDistanceCommand(SportContainsKeywordsPredicate predicate,
+                                          List<String> sportKeywordList, String postalCode) {
+        super(predicate, sportKeywordList);
+        this.postalCode = postalCode;
+        this.locationToBeCompared = LocationUtil.createLocation(new Address("temp"), postalCode);
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        // Use Sport.isValidSport to validate each sport
+        boolean hasInvalidSport = sportKeywordList.stream()
+                .anyMatch(sport -> !Sport.isValidSport(sport));
+
+        if (hasInvalidSport) {
+            return new CommandResult(MESSAGE_INVALID_SPORT);
+        }
+        model.updateFilteredPersonList(predicate);
+        model.sortFilteredPersonListByDistance(locationToBeCompared);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW,
+                        model.getFilteredPersonList().size()));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FindSportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindSportCommandParser.java
@@ -1,39 +1,68 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POSTAL_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindSportCommand;
+import seedu.address.logic.commands.FindSportSortByDistanceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Sport;
 import seedu.address.model.person.SportContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindSportCommand object.
  */
 public class FindSportCommandParser implements Parser<FindSportCommand> {
+
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected forma
+     * @throws ParseException if the user input does not conform the expected format
      */
     public FindSportCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_POSTAL_CODE, PREFIX_SPORT);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_SPORT) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindSportCommand.MESSAGE_USAGE));
+        }
+        // ParserUtil.parseSports throws an exception if any sport is invalid, so there is no need to handle it again
+        List<Sport> sports = ParserUtil.parseSports(argMultimap.getAllValues(PREFIX_SPORT));
+        if (sports.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindSportCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        // Normalize the keywords by converting to lowercase
-        List<String> sportList = Arrays.stream(nameKeywords)
-                .map(String::trim)
+        // Convert the Sports objects to String keywords then
+        // normalize the keywords by converting to lowercase
+        List<String> sportKeywordList = sports.stream()
+                .map(Sport::toString)
                 .map(String::toLowerCase)
                 .collect(Collectors.toList());
 
-        return new FindSportCommand(new SportContainsKeywordsPredicate(sportList), sportList);
+        //if postal code is provided, return FindSportSortByDistanceCommand
+        // ParserUtil.parsePostalCode throws an exception if the provided postal code is invalid,
+        // so there is no need to handle it again
+        if (arePrefixesPresent(argMultimap, PREFIX_POSTAL_CODE)) {
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_POSTAL_CODE);
+            String postalCode = ParserUtil.parsePostalCode(argMultimap.getValue(PREFIX_POSTAL_CODE).get());
+            return new FindSportSortByDistanceCommand(new SportContainsKeywordsPredicate(sportKeywordList),
+                    sportKeywordList, postalCode);
+        } else { //else return FindSportCommand as per usual
+            return new FindSportCommand(new SportContainsKeywordsPredicate(sportKeywordList), sportKeywordList);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.group.Group;
+import seedu.address.model.person.Location;
 import seedu.address.model.person.Person;
 
 /**
@@ -85,6 +86,13 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Sorts the filtered person list by distance from the given location.
+     *
+     * @param locationToBeCompared The location to compare the distance to.
+     */
+    void sortFilteredPersonListByDistance(Location locationToBeCompared);
 
     /** Returns an unmodifiable view of the filtered group list */
     ObservableList<Group> getFilteredGroupList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,14 +4,17 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.group.Group;
+import seedu.address.model.person.Location;
 import seedu.address.model.person.Person;
 
 /**
@@ -23,7 +26,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-
+    private final SortedList<Person> sortedPersons;
     private final FilteredList<Group> filteredGroups;
 
     /**
@@ -37,6 +40,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        sortedPersons = new SortedList<>(filteredPersons);
         filteredGroups = new FilteredList<>(this.addressBook.getGroupList());
     }
 
@@ -145,13 +149,30 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Person> getFilteredPersonList() {
-        return filteredPersons;
+        return sortedPersons;
     }
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
 
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    /**
+     * Sorts the filtered person list by distance from the given location.
+     *
+     * @param location The location to compare the distance to.
+     */
+    @Override
+    public void sortFilteredPersonListByDistance(Location location) {
+        requireNonNull(location);
+        Comparator<Person> comparator = Comparator.comparingDouble(person -> person.getLocation().distanceTo(location));
+        sortedPersons.setComparator(comparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -150,6 +150,10 @@ public class Person {
         return new SportList(sportsCopy);
     }
 
+    public Location getLocation() {
+        return this.location;
+    }
+
     /**
      * Delete a sport from the person's list of sports.
      */

--- a/src/main/java/seedu/address/model/person/SportList.java
+++ b/src/main/java/seedu/address/model/person/SportList.java
@@ -76,7 +76,7 @@ public class SportList implements Iterable<Sport> {
     }
 
     /**
-     * Adds all of the sports in the specified collection to this list.
+     * Adds all sports in the specified collection to this list.
      *
      * @param sports collection containing sports to be added to this list
      * @return true if this list changed as a result of the call

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.group.Group;
+import seedu.address.model.person.Location;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -166,6 +167,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void sortFilteredPersonListByDistance(Location location) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Group> getFilteredGroupList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -174,6 +180,8 @@ public class AddCommandTest {
         public void updateFilteredGroupList(Predicate<Group> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+
 
         @Override
         public ObservableList<Group> getGroupList() {

--- a/src/test/java/seedu/address/logic/parser/FindSportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindSportCommandParserTest.java
@@ -41,6 +41,7 @@ public class FindSportCommandParserTest {
                 new SportContainsKeywordsPredicate(normalizedKeywords),
                 normalizedKeywords);
 
+        //remember to always include " " before your arguments
         assertParseSuccess(parser, " " + PREFIX_SPORT + "soccer "
                 + PREFIX_SPORT + "cricket", expectedCommand);
 
@@ -64,7 +65,10 @@ public class FindSportCommandParserTest {
                 new SportContainsKeywordsPredicate(normalizedKeywords),
                 normalizedKeywords);
 
+        //remember to always include " " before your arguments
         assertParseSuccess(parser, " " + PREFIX_SPORT + "SoCCer "
                 + PREFIX_SPORT + "CRicKET", expectedCommand);
     }
+
+    //testing for postal code field will be introduced later
 }

--- a/src/test/java/seedu/address/logic/parser/FindSportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindSportCommandParserTest.java
@@ -41,10 +41,12 @@ public class FindSportCommandParserTest {
                 new SportContainsKeywordsPredicate(normalizedKeywords),
                 normalizedKeywords);
 
-        assertParseSuccess(parser, " s/soccer s/cricket", expectedCommand);
+        assertParseSuccess(parser, " " + PREFIX_SPORT + "soccer "
+                + PREFIX_SPORT + "cricket", expectedCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n s/soccer \n \t s/cricket  \t", expectedCommand);
+        assertParseSuccess(parser, " \n " + PREFIX_SPORT + "soccer \n \t "
+                + PREFIX_SPORT + "cricket  \t", expectedCommand);
     }
 
 
@@ -62,6 +64,7 @@ public class FindSportCommandParserTest {
                 new SportContainsKeywordsPredicate(normalizedKeywords),
                 normalizedKeywords);
 
-        assertParseSuccess(parser, " s/SoCCer s/CRicKET", expectedCommand);
+        assertParseSuccess(parser, " " + PREFIX_SPORT + "SoCCer "
+                + PREFIX_SPORT + "CRicKET", expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindSportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindSportCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SPORT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -40,11 +41,12 @@ public class FindSportCommandParserTest {
                 new SportContainsKeywordsPredicate(normalizedKeywords),
                 normalizedKeywords);
 
-        assertParseSuccess(parser, "soccer cricket", expectedCommand);
+        assertParseSuccess(parser, " s/soccer s/cricket", expectedCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n soccer \n \t cricket  \t", expectedCommand);
+        assertParseSuccess(parser, " \n s/soccer \n \t s/cricket  \t", expectedCommand);
     }
+
 
     /**
      * Tests parsing of mixed-case arguments, expecting lowercase conversion.
@@ -60,6 +62,6 @@ public class FindSportCommandParserTest {
                 new SportContainsKeywordsPredicate(normalizedKeywords),
                 normalizedKeywords);
 
-        assertParseSuccess(parser, "SoCCer CRicKET", expectedCommand);
+        assertParseSuccess(parser, " s/SoCCer s/CRicKET", expectedCommand);
     }
 }


### PR DESCRIPTION
This enhancement to findsport allows users to specify an optional postal code field for all found contacts to be sorted by their distance from the specified postal code.

Take note that users will not have to key in the `PREFIX_SPORT` (i.e. "s/") before every sport keyword to allowing for proper differentiation between the optional postal code field and the sport keywords.

Take note that `ModelManager::getFilteredPersonList()` has been changed to return the `SortedList<Person> sortedPersons` object , regardless of whether the findsport command includes the postal code for sorting. This is acceptable because a `SortedList<Person>` is still an `ObservableList<Person>` and share the same underlying `FilteredList<Person> filteredpersons` object, allowing this implementation to work for findsport commands regardless of whether a postal code is provided for the list to be sorted against!

Tests have not been implemented for the above command, and the findsport command with postal code causes a second run of  the findsport command without postal code to show the persons in the sorted by postal code order, until a new postal code is provided. We should discuss if this implementation is ideal and if need be, I am happy to find a way to get around this over the weekend.