### PR TITLE
Bug fix where list where alphabetical sort was case-sensitive

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -219,7 +219,7 @@ public class ModelManager implements Model {
      */
     @Override
     public void sortFilteredPersonListAlphabetically() {
-        Comparator<Person> comparator = Comparator.comparing(person -> person.getName().fullName);
+        Comparator<Person> comparator = Comparator.comparing(person -> person.getName().fullName.toLowerCase());
         sortedPersons.setComparator(comparator);
     }
 


### PR DESCRIPTION
Bug: Alphabetical sort actually sorts by capital letters before non capital letters, e.g. "B" comes before "a"

Fix: Make all names lowercase so that alphabetical sort now sorts automatically

Fixes #207 
